### PR TITLE
feat(backend): add :dependencyDashboard extension [no issue]

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -1,4 +1,5 @@
 {
+  "extends": [":dependencyDashboard"],
   "schedule": "after 9am and before 12am on monday",
   "reviewersFromCodeOwners": true,
   "rebaseStalePrs": false,


### PR DESCRIPTION
### Context

Suite à sondage : https://ornikar.slack.com/archives/C03NJ6U9B2P/p1704883863711459

### Solution

- Activation du Dependency Dashboard de Renovate pour suivre les upgrades qu'on doit réaliser
- Le backend Insurance utilise le preset `insurance-backend` qui étend le preset `backend`, mais ils ont déjà le dashboard d'actif via `config:js-app->config:recommanded` (cf. [github](https://github.com/ornikar/insurance-backend/blob/64501dda6d9ae8b71d785975b1d94692b432378f/renovate.json#L2) + [doc Renovate](https://docs.renovatebot.com/presets-config/#configjs-app))