### PR TITLE
feat: add ruby package specific rule [no issue]

### DIFF
--- a/frontend.json
+++ b/frontend.json
@@ -286,6 +286,12 @@
       "matchPackagePatterns": [
         "^@linaria/"
       ]
+    },
+    {
+      "groupName": "Ruby",
+      "reviewers": ["team:frontend-wg-foundations"],
+      "matchDatasources": ["rubygems", "ruby-version"],
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
### Context

Ruby étant installé avec homebrew sur nos machines, nous ne pouvons installer que le dernier patch d'une mineur (3.2.3). Hors il n'existe pas d'image macos sur circle avec cette version de ruby.

Mettre une range version sur la version ruby du gemfile permet de faire fonctionner à la fois la setup sur la CI et sur nos machines.

Renovate étant configuré pour tjrs set des versions fixes, il corrigera automatiquement cette range version pour la fixer: https://github.com/ornikar/instructors-app/pull/2932

### Solution

ajout d'une config renovate pour autoriser les range version pour les packages ruby.