### PR TITLE
chore(ins): add bot approval tag to ins backend deps prs [no issue]

### DIFF
--- a/insurance-backend.json
+++ b/insurance-backend.json
@@ -12,6 +12,7 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin"],
       "matchDepTypes": ["dependencies", "devDependencies"],
+      "addLabels": [":white_check_mark: bot approval"],
       "groupName": "autoupdate minors and patch",
       "schedule": ["after 9am and before 6pm every weekday"],
       "automerge": true,


### PR DESCRIPTION
### Context

No auto approval on minor/patch dependency PRs for INS Backend

### Solution

Apply tags from Frontend config.