### PR TITLE
chore(backend): use matchDepNames in config [no issue]

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -18,7 +18,7 @@
     {
       "groupName": "Ornikar Backend Orb",
       "matchDatasources": ["orb"],
-      "matchPackageNames": ["backend"],
+      "matchDepNames": ["backend"],
       "labels": ["circleci-orb"],
       "schedule": ["at any time"],
       "masterIssueApproval": false
@@ -26,7 +26,7 @@
     {
       "groupName": "Ornikar Ops Orb",
       "matchDatasources": ["orb"],
-      "matchPackageNames": ["ops"],
+      "matchDepNames": ["ops"],
       "labels": ["circleci-orb"],
       "schedule": ["at any time"],
       "masterIssueApproval": false


### PR DESCRIPTION
### Context

Repository problem flagged on Renovate dashboard.
Per [the doc](https://docs.renovatebot.com/configuration-options/#matchpackagenames):
```
matchPackageNames will try matching packageName first and then fall back to matching depName.
If the fallback is used, Renovate will log a warning, because the fallback will be removed in a
future release. Use matchDepNames instead.
```

### Solution

Use `matchDepNames`.
